### PR TITLE
Update config-mainnet.yaml - use new hyperfuel version

### DIFF
--- a/config-mainnet.yaml
+++ b/config-mainnet.yaml
@@ -3,6 +3,8 @@ name: builder-mainnet
 ecosystem: fuel
 networks:
 - id: 9889
+  hyperfuel_config:
+    url: https://mainnet2.hypersync.xyz
   start_block: 0
   contracts:
   - name: BuilderBonding


### PR DESCRIPTION
This is the new version of hyperfuel. It has more data validity checks, is faster - and nothing breaking for hyperindex. We haven't switched out domains since there is a team using hyperfuel directly who hasn't confirmed that nothing is breaking. So definitely recommend using it :)